### PR TITLE
Update AA selection to only select from standard set of AA

### DIFF
--- a/src/pgen/pgen_esm.py
+++ b/src/pgen/pgen_esm.py
@@ -3,7 +3,6 @@ from pgen.esm_sampler import ESM_sampler
 from pgen import models
 from pgen.utils import write_sequential_fasta
 from pathlib import Path
-import shutil
 
 model_map = {"esm1b":models.ESM1b, "esm6":models.ESM6, "esm12":models.ESM12, "esm34":models.ESM34}
 
@@ -19,8 +18,10 @@ def main(input_h, output_p, args):
                 name = line[0]
                 line_args = eval(line[1])
                 sequences = sampler.generate(args.num_output_sequences, seed_seq=line[2].upper(), batch_size=args.batch_size, **line_args)
-                write_sequential_fasta( output_p / (name + ".fasta"), sequences )
-
+                write_sequential_fasta( output_p / (name + ".fasta"), sequences)
+            else:
+                print(f"Expected 3 values in specification file (name, line_args, seed), got {len(line)}")
+                print("\t".join(line))
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/src/pgen/pgen_msa.py
+++ b/src/pgen/pgen_msa.py
@@ -30,6 +30,9 @@ def main(input_h, output_p, args):
 
                 sequences = gibbs_sampler.generate(args.num_output_sequences, seed_msa=input_msa, batch_size=args.batch_size, **line_args)
                 write_sequential_fasta( output_p / (name + ".fasta"), sequences )
+            else:
+                print(f"Expected 3 values in specification file (name, line_args, input_msa), got {len(line)}")
+                print("\t".join(line))
 
 
 if __name__ == "__main__":

--- a/test/test_esm_sampler.py
+++ b/test/test_esm_sampler.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 from pgen import models, esm_sampler
+from pgen.esm_sampler import generate_step, ESM_ALLOWED_AMINO_ACIDS
 
 
 ####### Fixtures #######
@@ -8,6 +9,7 @@ from pgen import models, esm_sampler
 @pytest.fixture
 def esm6(scope="session"):
     return models.ESM6()
+
 
 @pytest.fixture
 def esm_sampler_fixture(esm6, scope="session"):
@@ -19,7 +21,7 @@ def esm_sampler_fixture(esm6, scope="session"):
 ###### Tests #######
 
 def test_sampler_init_cpu(esm6):
-    
+
     sampler = esm_sampler.ESM_sampler(esm6, device="cpu")
     #TODO: test that the model is actually on the cpu
 
@@ -43,7 +45,7 @@ def test_get_init_seq_empty(esm_sampler_fixture):
 def test_generate_batch_equals_seqs(esm_sampler_fixture):
     sampler = esm_sampler_fixture
     out = sampler.generate(4, "", batch_size=4, max_len=10)
-    
+
     assert (len(out) == 4)
     for s in out:
         assert(len(s) == 10)
@@ -71,7 +73,7 @@ def test_generate_batch_with_varying_input(esm_sampler_fixture, batch_size, num_
 def test_generate_batch_greater_than_seqs(esm_sampler_fixture):
     sampler = esm_sampler_fixture
     out = sampler.generate(4, "", batch_size=10, max_len=10)
-    
+
     assert (len(out) == 4)
     for s in out:
         assert(len(s) == 10)
@@ -83,7 +85,7 @@ def test_generate_batch_greater_than_seqs(esm_sampler_fixture):
 def test_get_target_index_in_order(esm_sampler_fixture):
     sampler = esm_sampler_fixture
     last_i, target_indexes = sampler.get_target_index_in_order(
-        batch_size=2, indexes=[0,1,2,3], next_i=1, num_positions=2)
+        batch_size=2, indexes=[0, 1, 2, 3], next_i=1, num_positions=2)
 
     assert len(target_indexes) == 2
     assert last_i == 3
@@ -92,7 +94,7 @@ def test_get_target_index_in_order(esm_sampler_fixture):
 
 def test_get_target_index_randomly(esm_sampler_fixture):
     sampler = esm_sampler_fixture
-    indexes = [0,1,2,3]
+    indexes = [0, 1, 2, 3]
     target_indexes = sampler.get_random_target_index(
         batch_size=2, indexes=indexes, num_positions=3)
 
@@ -114,3 +116,107 @@ def test_mask_indexes(esm_sampler_fixture):
     assert batch == [
         [1, 1, 33, 33], [1, 33, 33, 1], [33, 33, 1, 1]
     ]
+
+
+def map_aa_idx_to_tok_set(esm_sampler_fixture):
+    return set(esm_sampler_fixture.model.alphabet.get_tok(idx) for idx in esm_sampler_fixture.valid_aa_idx)
+
+
+def test_allowable_amino_acid_locations_only_contain_standard_aa(esm_sampler_fixture):
+    standard_toks = set(esm_sampler_fixture.model.alphabet.standard_toks)
+    actual_allowed = map_aa_idx_to_tok_set(esm_sampler_fixture)
+
+    assert actual_allowed.issubset(standard_toks)
+    assert actual_allowed == set(ESM_ALLOWED_AMINO_ACIDS)
+
+
+def test_allowable_amino_acid_locations_do_not_contain_amino_acids_we_cant_create(esm_sampler_fixture):
+    actual_allowed = map_aa_idx_to_tok_set(esm_sampler_fixture)
+    non_single_standard = set("XBUXZO.-")
+
+    assert actual_allowed.isdisjoint(non_single_standard)
+
+
+def test_generate_step_without_idx_restriction():
+    cnts = {idx: 0 for idx in range(6)}
+    for _ in range(1000):
+        out = torch.tensor([[.1, .1, .1, .1, .1, .1]])
+        gen_idx = 0
+        idx = generate_step(out, gen_idx)
+        cnts[idx.item()] += 1
+
+    print(cnts)
+    assert cnts[0] > 100
+    assert cnts[1] > 100
+    assert cnts[2] > 100
+    assert cnts[3] > 100
+    assert cnts[4] > 100
+    assert cnts[5] > 100
+
+
+def test_generate_step_with_idx_restriction():
+    valid_idx = [1, 3, 5]
+    cnts = {idx: 0 for idx in range(6)}
+    for _ in range(1000):
+        out = torch.tensor([[.1, .1, .1, .1, .1, .1]])
+        gen_idx = 0
+        idx = generate_step(out, gen_idx, valid_idx=valid_idx)
+        cnts[idx.item()] += 1
+
+    print(cnts)
+    assert cnts[0] == 0
+    assert cnts[1] > 200
+    assert cnts[2] == 0
+    assert cnts[3] > 200
+    assert cnts[4] == 0
+    assert cnts[5] > 200
+
+
+def test_generate_step_with_idx_restriction_and_top_k():
+    valid_idx = [1, 3, 5]
+    cnts = {idx: 0 for idx in range(6)}
+    for _ in range(1000):
+        out = torch.tensor([[.4, .2, .4, .2, .1, .1]])
+        gen_idx = 0
+        idx = generate_step(out, gen_idx, top_k=2, valid_idx=valid_idx)
+        cnts[idx.item()] += 1
+
+    print(cnts)
+    assert cnts[0] == 0
+    assert cnts[1] > 400
+    assert cnts[2] == 0
+    assert cnts[3] > 400
+    assert cnts[4] == 0
+    assert cnts[5] == 0  # excluded from top k
+
+
+def test_generate_step_with_out_of_order_idx_restriction():
+    valid_idx = [3, 5, 1]
+    cnts = {idx: 0 for idx in range(6)}
+    for _ in range(1000):
+        out = torch.tensor([[.4, .2, .4, .2, .1, .1]])
+        gen_idx = 0
+        idx = generate_step(out, gen_idx, top_k=2, valid_idx=valid_idx)
+        cnts[idx.item()] += 1
+
+    print(cnts)
+    assert cnts[0] == 0
+    assert cnts[1] > 400
+    assert cnts[2] == 0
+    assert cnts[3] > 400
+    assert cnts[4] == 0
+    assert cnts[5] == 0  # excluded from top k
+
+
+def test_generate_batch_only_includes_allowed_aa(esm_sampler_fixture):
+    out = esm_sampler_fixture.generate(10, "", batch_size=10, max_len=25)
+
+    allowed = set(ESM_ALLOWED_AMINO_ACIDS)
+    for sequence in out:
+        assert len({s for s in sequence}.difference(allowed)) == 0
+
+
+# def test_generate_batch_does_not_leave_unmasked_characters(esm_sampler_fixture):
+#     out = esm_sampler_fixture.generate(1, "", num_iters=1, max_len=5, num_positions=1)
+#
+#     assert "<mask>" not in out[0]


### PR DESCRIPTION
There are two commented out tests at the bottom of each test file, which I think is still a scenario we could get the <mask>. If we don't specify enough positions & iterations to cover the initial masking to make the seed the length of the max length. I think in our testing though the input sequences are as long as the max length? 